### PR TITLE
change path of generated TextMate grammar

### DIFF
--- a/lang/frontend/language/workflow/generate.mwe2
+++ b/lang/frontend/language/workflow/generate.mwe2
@@ -37,7 +37,7 @@ Workflow {
 			grammarUri = "${rootPath}/language/src/main/xtext/tools/vitruv/neojoin/NeoJoin.xtext"
 
 			fragment = TextMateHighlightingFragment {
-				absolutePath = "${rootPath}/ide/target/"
+				absolutePath = "${rootPath}/ide/src-gen/"
 			}
 
 			parserGenerator = {}


### PR DESCRIPTION
prevents the grammar from being cleaned in the subsequent build of the IDE module