### PR TITLE
fix mwe2 workflow on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
         --no-transfer-progress
 
     - name: Stage build results
+      if: matrix.os == 'ubuntu-latest'
       run: mkdir staging && find . -path '*/target/*.jar' -exec cp {} staging/ \;
 
     - name: Upload build results
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
         name: build-results-maven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ on:
 jobs:
   build-maven:
     name: Build Maven projects
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - name: Checkout repository

--- a/lang/frontend/language/workflow/generate.mwe2
+++ b/lang/frontend/language/workflow/generate.mwe2
@@ -34,7 +34,7 @@ Workflow {
 		language = StandardLanguage {
 			name = "tools.vitruv.neojoin.NeoJoin"
 			fileExtensions = "nj"
-			grammarUri = "${rootPath}/language/src/main/xtext/tools/vitruv/neojoin/NeoJoin.xtext"
+			grammarUri = "frontend/language/src/main/xtext/tools/vitruv/neojoin/NeoJoin.xtext"
 
 			fragment = TextMateHighlightingFragment {
 				absolutePath = "${rootPath}/ide/src-gen/"


### PR DESCRIPTION
`${rootPath}` on Windows contains the drive letter (e.g. `C:`). Given that the path to the grammar is a URI (`grammarUri`), this is interpreted as the protocol part of the URI which leads to errors. Using a relative path seems to work on Linux and Windows.