### PR TITLE
fix potentially wrong error message for root class naming collision

### DIFF
--- a/lang/frontend/language/src/main/java/tools/vitruv/neojoin/validation/NeoJoinValidator.java
+++ b/lang/frontend/language/src/main/java/tools/vitruv/neojoin/validation/NeoJoinValidator.java
@@ -48,7 +48,7 @@ public class NeoJoinValidator extends AbstractNeoJoinValidator {
                     error(
                         ("Target class name '%s' collides with name of the implicit root class. " +
                             "Either choose a different name for this class or explicitly create a root class with a different name.")
-                            .formatted(query.getName()),
+                            .formatted(Constants.DefaultRootClassName),
                         query,
                         query.getName() != null ? AstPackage.Literals.QUERY__NAME : null
                     );

--- a/lang/frontend/language/src/test/java/tools/vitruv/neojoin/parse/RootParseTest.java
+++ b/lang/frontend/language/src/test/java/tools/vitruv/neojoin/parse/RootParseTest.java
@@ -42,7 +42,7 @@ public class RootParseTest extends AbstractParseTest {
     void featureNameConflict() {
         var result = parse("""
             from Food create
-            
+
             create root Rooty {
                 allFoods := 5
             }
@@ -67,6 +67,21 @@ public class RootParseTest extends AbstractParseTest {
     void implicitRootNameCollision() {
         var result = parse("""
             create Root {}
+            """);
+
+        assertThat(result)
+            .hasIssues("Target class name 'Root' collides with name of the implicit root class. " +
+                "Either choose a different name for this class or explicitly create a root class with a different name.");
+    }
+
+    @Test
+    void implicitRootNameCollisionWithImplicitName() {
+        var result = internalParse("""
+            export package to "http://example.com"
+
+            import "http://vitruv.tools/cyclic"
+
+            from Root create {}
             """);
 
         assertThat(result)


### PR DESCRIPTION
Previously, the name of the target class was incorrectly stated as `null`
if the name was not explicitly specified but inferred from the source class.

Example: `Target class name 'null' collides ...`

*Depends on #83 because it reuses the model introduced there.*