### PR TITLE
fix path to the jar file in the vscode plugin

### DIFF
--- a/vscode-plugin/src/lsp/index.ts
+++ b/vscode-plugin/src/lsp/index.ts
@@ -40,7 +40,7 @@ const EXEC_OPTIONS = (() => {
         };
     } else {
         return {
-            jarFile: "ide.jar",
+            jarFile: "tools.vitruv.neojoin.frontend.ide.jar",
             jvmOpts: [],
             programOpts: config.debug
                 ? ["--trace", "--log", debugLogFilePath()]


### PR DESCRIPTION
Currently, the language server does not work because the specified jar file does not exist.