### PR TITLE
Allow `null` as result value

### DIFF
--- a/lang/frontend/language/src/main/java/tools/vitruv/neojoin/utils/Result.java
+++ b/lang/frontend/language/src/main/java/tools/vitruv/neojoin/utils/Result.java
@@ -1,5 +1,7 @@
 package tools.vitruv.neojoin.utils;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents the result of an operation that can either {@link Success succeed} by returning a value or {@link Failure fail}
  * with an exception.
@@ -9,11 +11,11 @@ package tools.vitruv.neojoin.utils;
 public sealed interface Result<T> {
 
     record Success<T>(
-        T value
+        @Nullable T value
     ) implements Result<T> {}
 
     record Failure<T>(
-        Throwable throwable
+        @Nullable Throwable throwable
     ) implements Result<T> {}
 
 }


### PR DESCRIPTION
This is needed, e.g., here: https://github.com/vitruv-tools/NeoJoin/blob/031e17a7ab8de03504057cdc2cadbf3462aea114/lang/frontend/language/src/main/java/tools/vitruv/neojoin/jvmmodel/ExpressionHelper.java#L150